### PR TITLE
Update Work Order Status page

### DIFF
--- a/src/app/pages/work-order-status/work-order-status.component.html
+++ b/src/app/pages/work-order-status/work-order-status.component.html
@@ -2,21 +2,23 @@
   <h2 class="wo-title">Work Order Status</h2>
 
   <!-- Nút mở Google Sheet -->
-  <button class="edit-sheet-btn" (click)="openGoogleSheet()">
-    <span style="display:flex;align-items:center;">
-      <i class="material-icons" style="font-size:18px;margin-right:4px;">edit</i>
-      Edit on Google Sheet
-    </span>
-  </button>
+  <div class="edit-sheet-wrapper">
+    <button class="edit-sheet-btn" (click)="openGoogleSheet()">
+      <span style="display:flex;align-items:center;">
+        <i class="material-icons" style="font-size:18px;margin-right:4px;">edit</i>
+        Edit on Google Sheet
+      </span>
+    </button>
+  </div>
 
   <!-- Dropdown filter -->
   <div style="margin-bottom: 16px;">
-    <label style="font-weight:500;">Y:</label>
+    <label class="filter-label">Y:</label>
     <select [(ngModel)]="selectedYear" (change)="filterData()" style="margin-right:10px;">
       <option value="">-- Tất cả --</option>
       <option *ngFor="let y of years" [value]="y">{{y}}</option>
     </select>
-    <label style="font-weight:500;">M:</label>
+    <label class="filter-label">M:</label>
     <select [(ngModel)]="selectedMonth" (change)="filterData()">
       <option value="">-- Tất cả --</option>
       <option *ngFor="let m of months" [value]="m">{{m}}</option>
@@ -36,15 +38,15 @@
     <table *ngIf="workOrders.length > 0" class="wo-table">
       <thead>
         <tr>
-          <th *ngFor="let col of columns" [class.sticky]="col === 'Work Order'">{{col}}</th>
+          <th *ngFor="let col of columns" [class.sticky]="isWorkOrder(col)">{{col}}</th>
           <th class="actions-col">Actions</th>
         </tr>
       </thead>
       <tbody>
         <tr *ngFor="let row of workOrders; let i=index" [class.odd]="i%2===0" [class.even]="i%2===1">
-          <td *ngFor="let col of columns" [class.sticky]="col === 'Work Order'">
+          <td *ngFor="let col of columns" [class.sticky]="isWorkOrder(col)">
             <ng-container *ngIf="editIndex === i; else viewOnly">
-              <input [(ngModel)]="workOrders[i][col]" class="wo-input" (keydown.enter)="saveRow(i)" />
+              <input [(ngModel)]="workOrders[i][col]" class="wo-input" (keydown.enter)="saveRow(i)" (blur)="saveRow(i)" />
             </ng-container>
             <ng-template #viewOnly>
               {{row[col]}}
@@ -64,12 +66,12 @@
     <table class="wo-table">
       <thead>
         <tr>
-          <th *ngFor="let col of columns" [class.sticky]="col === 'Work Order'">{{col}}</th>
+          <th *ngFor="let col of columns" [class.sticky]="isWorkOrder(col)">{{col}}</th>
         </tr>
       </thead>
       <tbody>
         <tr *ngFor="let row of workOrders; let i=index" [class.odd]="i%2===0" [class.even]="i%2===1">
-          <td *ngFor="let col of columns" [class.sticky]="col === 'Work Order'">
+          <td *ngFor="let col of columns" [class.sticky]="isWorkOrder(col)">
             {{row[col]}}
           </td>
         </tr>

--- a/src/app/pages/work-order-status/work-order-status.component.scss
+++ b/src/app/pages/work-order-status/work-order-status.component.scss
@@ -244,3 +244,13 @@ button:active {
 .edit-sheet-btn:hover {
   background: #1565c0;
 }
+
+.edit-sheet-wrapper {
+  text-align: left;
+  margin-bottom: 12px;
+}
+
+.filter-label {
+  font-weight: 500;
+  color: #000;
+}

--- a/src/app/pages/work-order-status/work-order-status.component.ts
+++ b/src/app/pages/work-order-status/work-order-status.component.ts
@@ -10,6 +10,7 @@ export class WorkOrderStatusComponent implements OnInit {
   workOrders: any[] = [];
   allWorkOrders: any[] = [];
   columns: string[] = [];
+  options: any = {};  // options received from backend
   loading = true;
   errorMsg = '';
   GAS_URL = 'https://script.google.com/macros/s/AKfycbzAkZjhsjdwSok1CfciFAhftU_J2X3ZQs22JLjGAXINds1VxhdXbAtYvPd3Zq3Xl1Kc/exec';
@@ -42,6 +43,7 @@ export class WorkOrderStatusComponent implements OnInit {
       next: (resp) => {
         this.columns = resp.columns; // lấy đúng tiêu đề dòng 4, đúng thứ tự
         this.allWorkOrders = resp.data;
+        this.options = resp.options || {};
         this.years = this.getYearsList();
         this.filterData();
         this.loading = false;

--- a/src/app/pages/work-order-status/work-order-status.component.ts
+++ b/src/app/pages/work-order-status/work-order-status.component.ts
@@ -33,6 +33,10 @@ export class WorkOrderStatusComponent implements OnInit {
 
   constructor(private http: HttpClient) {}
 
+  isWorkOrder(col: string): boolean {
+    return col.trim().toLowerCase() === 'work order';
+  }
+
   ngOnInit(): void {
     this.http.get<any>(this.GAS_URL).subscribe({
       next: (resp) => {


### PR DESCRIPTION
## Summary
- tweak labels and layout on Work Order Status page
- move Google Sheet edit button to the top-left
- ensure `Work Order` column detection is case-insensitive
- autosave on cell blur

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a5d9f388331a4fd3605367662f9